### PR TITLE
Fix dashboard refresh

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -71,10 +71,12 @@ func Run(dashboards []dashboard.Dashboard, initialInterval, initialRefresh strin
 		for {
 			select {
 			case <-ticker.C:
-				fLog.Debugf("refresh was triggered")
-				statusbar.Update(t.Size().X)
-				gridOpts = widget.GridLayout(storage)
-				c.Update("layout", container.SplitHorizontal(container.Top(container.PlaceWidget(statusbar)), container.Bottom(gridOpts...), container.SplitFixed(1)))
+				if !modalActive {
+					fLog.Debugf("refresh was triggered")
+					storage.RefreshInterval()
+					gridOpts = widget.GridLayout(storage)
+					c.Update("layout", container.SplitHorizontal(container.Top(container.PlaceWidget(statusbar)), container.Bottom(gridOpts...), container.SplitFixed(1)))
+				}
 			case <-ctx.Done():
 				return
 			}
@@ -127,6 +129,8 @@ func Run(dashboards []dashboard.Dashboard, initialInterval, initialRefresh strin
 			c.Update("layout", container.SplitHorizontal(container.Top(container.PlaceWidget(statusbar)), container.Bottom(container.PlaceWidget(modal)), container.SplitFixed(1)))
 		case keyboard.KeyEsc:
 			modalActive = false
+			storage.RefreshInterval()
+			gridOpts = widget.GridLayout(storage)
 			c.Update("layout", container.SplitHorizontal(container.Top(container.PlaceWidget(statusbar)), container.Bottom(gridOpts...), container.SplitFixed(1)))
 		}
 


### PR DESCRIPTION
The dashboard wasn't refreshed in the given refresh time, because the
start and end time of the interval were not updated befor the refresh
was triggered.

Also the refresh function isn't executed if the modal is closed without
action (ESC), because the refresh function closed the modal every time.
This was a bit frustrating specially for small time intervals.

Instead the dashboard is refreshed when the modal is closed.