### PR TITLE
Add explore mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ By default dash will look at `~/.dash` for the datasources and dashboards. To ch
 
 To set the initial interval and refresh rate you can use the `--config.interval` and `--config.refresh` flag. To enable the debug logs you can pass the `--debug` flag to dash.
 
+dash also supports an **explore** mode, where you can query your datasources without the need for a dashboard. The explore mode can be called via the `explore` command. You can also pass an optional query to the explore mode:
+
+```sh
+dashboard explore --query 'node_load1{cluster="main"}'
+```
+
 ### Datasources
 
 The configuration file for a datasource looks as follows:
@@ -172,6 +178,7 @@ Use the following keys to navigate within dash:
 | `<0-9>` | Provide the index for a value in the modal. |
 | `F1` | Open the dashboards modal. |
 | `F2` | Open the datasource modal. |
-| `F3` + `<1-9>` | Open the modal for a variable. Press `v` plus a number from `1` to `9` to select the variable. |
+| `F3` | Open the query modal in the explore mode. |
+| `F3` + `<1-9>` | Open the modal for a variable. Press `F3` plus a number from `1` to `9` to select the variable. |
 | `F4` | Open the interval modal. |
 | `F5` | Open the refresh rate modal. |

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -44,3 +44,31 @@ func New(dir string) ([]Dashboard, error) {
 
 	return dashboards, nil
 }
+
+func Explore(query string) ([]Dashboard, error) {
+	dashboard := Dashboard{
+		Name: "Explore",
+		Rows: []Row{
+			{
+				Height: 99,
+				Graphs: []Graph{
+					{
+						Width: 99,
+						Type:  "linechart",
+						Title: "Explore",
+						Queries: []Query{
+							{
+								Query: query,
+							},
+						},
+						Options: Options{
+							Legend: "bottom",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return []Dashboard{dashboard}, nil
+}

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -50,6 +50,7 @@ type Client interface {
 	GetVariableValues(query, label string, start, end time.Time) ([]string, error)
 	GetData(queries, labels []string, start, end time.Time) (*Data, error)
 	GetTableData(queries, labels []string) (*TableData, error)
+	GetSuggestions() ([]string, error)
 }
 
 func New(dir string) (map[string]Client, error) {

--- a/pkg/datasource/prometheus.go
+++ b/pkg/datasource/prometheus.go
@@ -193,6 +193,23 @@ func (p *Prometheus) GetTableData(queries, labels []string) (*TableData, error) 
 	return &tableData, nil
 }
 
+func (p *Prometheus) GetSuggestions() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, _, err := p.v1api.LabelValues(ctx, "__name__")
+	if err != nil {
+		return nil, err
+	}
+
+	var values []string
+	for _, val := range result {
+		values = append(values, string(val))
+	}
+
+	return values, nil
+}
+
 func getTimeRange(options Options, start, end time.Time) v1.Range {
 	var step = 10 * time.Second
 	if options.MaxPoints != 0 {

--- a/pkg/render/widget/statusbar.go
+++ b/pkg/render/widget/statusbar.go
@@ -40,6 +40,9 @@ func (s *Statusbar) Update(termWidth int) {
 	dashboard := fmt.Sprintf(" [F1] Dashboard: %s", s.storage.Dashboard().Name)
 	datasource := fmt.Sprintf(" [F2] Datasource: %s", s.storage.ActiveDatasource)
 	variables := fmt.Sprintf(" [F3] Variables: %s", strings.Join(prefixedValues, ", "))
+	if s.storage.Explore.Enabled {
+		variables = fmt.Sprintf(" [F3] Query: %s", s.storage.Dashboard().Rows[0].Graphs[0].Queries[0].Query)
+	}
 	interval := fmt.Sprintf(" [F4] Interval: %s", s.storage.Interval.Interval)
 	refresh := fmt.Sprintf(" [F5] Refresh: %s ", s.storage.Refresh)
 	spaces := strings.Repeat(" ", termWidth-len(dashboard)-len(datasource)-len(variables)-len(interval)-len(refresh))


### PR DESCRIPTION
Add a new "explore" command option, to enter the explore mode of dash. The explore mode can be used to directly query your datasource, with out the need to build a dashboard.

The explore mode supports a "query" flag, which let you pass a query to the explore mode.

To add the support mode a new method for the datasources was added. Also the linechart component was adjusted to support better rendering of the legend in the new mode. Instead of the Variables the query is shown in the statusbar.

**Example:**

```sh
./bin/dash explore --config.dir ./examples --debug --config.interval 5m --query 'node_load1{cluster="main"}'
```

![Bildschirmfoto 2020-04-20 um 22 18 31](https://user-images.githubusercontent.com/18552168/79795885-ed4d9e80-8354-11ea-962a-f999eecf166d.png)
