### PR TITLE
Add config option to skip TLS verification

### DIFF
--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -16,9 +16,10 @@ var (
 )
 
 type Auth struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	Token    string `yaml:"token"`
+	Username              string `yaml:"username"`
+	Password              string `yaml:"password"`
+	Token                 string `yaml:"token"`
+	InsecureSkipTLSVerify bool   `yaml:"insecureSkipTLSVerify"`
 }
 
 type Options struct {


### PR DESCRIPTION
Add a new configuration option `insecureSkipTLSVerify` for the Prometheus datasource. If this option is set to `true` TLS verification for all requests will be skipped.

Documentation: https://github.com/ricoberger/dash/wiki/Prometheus

Closes #12.